### PR TITLE
Reorganize config

### DIFF
--- a/buchschloss/cli.py
+++ b/buchschloss/cli.py
@@ -1,5 +1,5 @@
 """CLI for buchschloss"""
-
+import collections
 import shlex
 import argparse
 import ast
@@ -62,7 +62,8 @@ def execute(command, args, kwargs):
         display encountered errors
     """
     func = COMMANDS[command]
-    kwargs['login_context'] = current_login
+    if command in EXTERNAL_COMMANDS:
+        kwargs['login_context'] = current_login
     try:
         f_args = inspect.signature(func).parameters.keys()
     except (TypeError, ValueError):
@@ -267,9 +268,7 @@ def foreach(iterable):
             handle_user_input(ui)
 
 
-COMMANDS = {
-    'login': login,
-    'logout': logout,
+EXTERNAL_COMMANDS = {
     'new_person': core.Person.new,
     'edit_person': core.Person.edit,
     'view_person': core.Person.view_str,
@@ -292,6 +291,10 @@ COMMANDS = {
     'restitute': core.Borrow.restitute,
     'view_borrow': core.Borrow.view_str,
     'search_borrow': core.Borrow.search,
+}
+INTERNAL_COMMANDS = {
+    'login': login,
+    'logout': logout,
     'help': help,
     'list': lambda x: tuple(x),
     'build_list': lambda *a: a,
@@ -303,6 +306,7 @@ COMMANDS = {
     'vars': lsvars,
     'foreach': foreach,
 }
+COMMANDS = collections.ChainMap(EXTERNAL_COMMANDS, INTERNAL_COMMANDS)
 variables = {}
 current_login = core.guest_lc
 

--- a/buchschloss/cli.py
+++ b/buchschloss/cli.py
@@ -169,14 +169,17 @@ def handle_user_input(ui):
 
 def ask(question):
     """Ask a yes/no question"""
-    print(utils.get_name('cli::interactive_question::' + question))
-    r = input()
-    return r and r[0].lower() in 'yj'  # TODO: make this configurable
+    r = ''
+    valid_answers = config.cli.answers.yes + config.cli.answers.no
+    while not r or r.lower() not in valid_answers:
+        print(utils.get_name('cli::interactive_question::' + question))
+        r = input().lower()
+    return r.lower() in config.cli.answers.yes
 
 
 def start():
     """Entry point. Provide a REPL"""
-    print(config.gui2.intro.text, end='\n\n')  # TODO: have a separate config section
+    print(config.cli.intro.text, end='\n\n')
     try:
         while True:
             try:

--- a/buchschloss/config/__init__.py
+++ b/buchschloss/config/__init__.py
@@ -9,7 +9,7 @@ _config_data = _main.get_config()
 def start():
     """provide config feedback to STDOUT"""
     print('No configuration errors found.')
-    if (_config_data['debug']
+    if (_config_data.debug
             and input('Do you want to see the current settings? ')
             .lower().startswith('y')):
         _pprint.pprint(_config_data.mapping)

--- a/buchschloss/config/__init__.py
+++ b/buchschloss/config/__init__.py
@@ -1,226 +1,28 @@
-"""Get configuration settings"""
+"""Provide attribute access to configuration settings"""
+import sys as _sys
+import pprint as _pprint
+from . import main as _main
 
-import os
-import sys
-import datetime
-import json
-import contextlib
-from collections.abc import Mapping
-import pprint
-import typing as T
-
-import configobj
-
-from .validation import validator
-
-MODULE_DIR = os.path.dirname(__file__)
-INCLUDE_NAME = 'include'  # I'd love to make this configurable...
-config_data = None
-ExceptSpec = T.Union[T.Type[BaseException], T.Tuple[T.Type[BaseException], ...]]
-ActuallyPathLike = T.Union[bytes, str, os.PathLike]
+_config_data = _main.get_config()
 
 
-class ConfigError(Exception):
-    """configuration error"""
-
-
-class DummyErrorFile:
-    """Revert errors to log.
-
-    Attributes:
-        error_happened: True if write() was called
-        error_file: the log file name
-        error_texts: list of the error messages wrote to the log file for later use
-            e.g. display, email, ..."""
-
-    def __init__(self, error_file='error.log'):
-        self.error_happened = False
-        self.error_texts = []
-        self.error_file = 'error.log'
-        with open(error_file, 'a', encoding='UTF-8') as f:
-            f.write('\n\nSTART: ' + str(datetime.datetime.now()) + '\n')
-
-    def write(self, msg):
-        self.error_happened = True
-        self.error_texts.append(msg)
-        while True:
-            try:
-                with open(self.error_file, 'a', encoding='UTF-8') as f:
-                    f.write(msg)
-            except OSError:
-                pass
-            else:
-                break
-
-
-class AttrAccess:
-    """Provide attribute access to mappings, supporting nesting"""
-    EMPTY_INST = type('', (), {'__repr__': lambda s: 'AttrAccess.EMPTY_INST'})()
-
-    def __init__(self, mapping):
-        self.mapping = mapping
-
-    def get(self, item, fallback=EMPTY_INST):
-        """return ``item`` if present, otherwise the given fallback
-            (an empty AttrAccess instance by default)"""
-        if fallback is self.EMPTY_INST:
-            fallback = type(self)({})
-        val = self.mapping.get(item, fallback)
-        if isinstance(val, Mapping):
-            val = type(self)(val)
-        return val
-
-    def __getitem__(self, item):
-        return self.mapping[item]
-
-    def __getattr__(self, item):
-        val = self.mapping[item.replace('_', ' ')]
-        if isinstance(val, Mapping):
-            val = type(self)(val)
-        return val
-
-
-def load_file(path: ActuallyPathLike,
-              loader: T.Callable[[T.TextIO], T.MutableMapping] = configobj.ConfigObj,
-              load_error: ExceptSpec = configobj.ConfigObjError,
-              ) -> T.Tuple[configobj.ConfigObj, T.Set[ActuallyPathLike]]:
-    """recursively load a file as ConfigObj. Return (<ConfigObj>, <set of invalid paths>)
-
-        The invalid paths returned may be nonexistent or unparseable
-        ``loader`` specifies how to load the file
-        ``load_error`` is used to catch exceptions while loading the file
-    """
-    def include_config(section: configobj.Section):
-        """recursively read included files and merge"""
-        for k, v in section.items():
-            if k == INCLUDE_NAME:
-                if isinstance(v, str):
-                    v = [v]
-                elif isinstance(v, configobj.Section):
-                    continue  # could also raise an error or add some filename to errors
-                del section[k]
-                for new_file in v:
-                    new_section, new_errors = load_file(new_file, loader, load_error)
-                    section.merge(new_section)
-                    errors.update(new_errors)
-            elif isinstance(v, configobj.Section):
-                include_config(v)
-
-    errors = set()
-    try:
-        f = open(path)
-    except OSError:
-        return configobj.ConfigObj({}), {path}
-    try:
-        config = loader(f)
-    except load_error:
-        return configobj.ConfigObj({}), {path}
-    finally:
-        f.close()
-    if not isinstance(config, configobj.ConfigObj):
-        config = configobj.ConfigObj(config)
-    include_config(config)
-    return config, errors
-
-
-def load_names(name_file: ActuallyPathLike,
-               name_format: str
-               ) -> T.Mapping:
-    """Load the name file with inclusions ignoring errors"""
-    def convert_name_data(data):
-        if isinstance(data, str):
-            return data
-        elif isinstance(data, T.Mapping):
-            return {k.lower(): convert_name_data(v) for k, v in data.items()}
-        else:
-            return ''
-
-    loaders = {
-        'json': (json.load, json.JSONDecodeError),
-        'configobj': (configobj.ConfigObj, configobj.ConfigObjError),
-    }
-    name_data, __ = load_file(name_file, *loaders[name_format])
-    # special case the only list
-    level_list = name_data.pop('level names', ())
-    if not isinstance(level_list, T.Sequence) or len(level_list) != 5:
-        level_list = ['level_{}'.format(i) for i in range(5)]
-    processed_data = convert_name_data(name_data)
-    processed_data['level names'] = level_list
-    return processed_data
-
-
-def start(noisy_success=True):
-    """load the config file specified in the BUCHSCHLOSS_CONFIG environment variable
-        and validate the settings"""
-    try:
-        filename = os.environ['BUCHSCHLOSS_CONFIG']
-    except KeyError:
-        raise ConfigError('environment variable BUCHSCHLOSS_CONFIG not found') from None
-    config, invalid_files = load_file(filename)
-    config = configobj.ConfigObj(
-        config, configspec=os.path.join(MODULE_DIR, 'configspec.cfg'))
-    val = config.validate(validator)
-    if isinstance(val, Mapping):  # True if successful, dict if not
-        with contextlib.redirect_stdout(sys.stderr):
-            print('--- ERROR IN CONFIG FILE FORMAT ---\n')
-
-            def pprint_errors(errors, nesting=''):
-                """display errors"""
-                for k, v in errors.items():
-                    if isinstance(v, dict):
-                        print(nesting + '\\_', k)
-                        pprint_errors(v, nesting + ' |')
-                    else:
-                        print(nesting, k, 'OK' if v else 'INVALID')
-
-            pprint_errors(val)
-            print('\n\nSee the confspec.cfg file for information on how the data has to be')
-            if invalid_files:
-                print('\nThe following configuration files could not be loaded:')
-                print('\n'.join(invalid_files))
-        sys.exit(1)
-    else:
-        config['utils']['names'] = load_names(
-            config['utils']['names']['file'], config['utils']['names']['format'])
-        # multiline defaults aren't allowed (AFAIK)
-        if config['gui2']['intro']['text'] is None:
-            config['gui2']['intro']['text'] = \
-                'Buchschloss\n\nhttps://github.com/mik2k2/buchschloss'
-
-        if ((config['utils']['email']['smtp']['username'] is None)
-                ^ (config['utils']['email']['smtp']['password'] is None)):
-            raise ConfigError(
-                'smtp.username and smtp.password must both be given or omitted')
-        if noisy_success:
-            print('YAY, no configuration errors found')
-        if invalid_files:
-            with contextlib.redirect_stdout(sys.stderr):
-                print('\nThe following configuration files could not be loaded:')
-                print('\n'.join(invalid_files))
-                print()
-        if (config['debug']
-                and noisy_success
-                and input('Do you want to see the current settings? ')
-                .lower().startswith('y')):
-            pprint.pprint(config)
-        if not config['debug']:
-            sys.stderr = DummyErrorFile()
-        return config
+def start():
+    """load config data and provide feedback to STDOUT"""
+    print('No configuration errors found.')
+    if (_config_data['debug']
+            and input('Do you want to see the current settings? ')
+            .lower().startswith('y')):
+        _pprint.pprint(_config_data.mapping)
 
 
 def __getattr__(name):
-    global config_data
-    if config_data is None:
-        config_data = AttrAccess(start(False))
-    val = getattr(config_data, name)
+    val = getattr(_config_data, name)
     globals()[name] = val
     return val
 
 
-if sys.version_info < (3, 7):
+if _sys.version_info < (3, 7):
     # pre-3.7 don't support module-level __getattr__
     # get configuration now and assign top-level structures
-    config_data = AttrAccess(start(False))
-    for k, v in config_data.mapping.items():
-        globals()[k] = AttrAccess(v)
-    debug = config_data['debug']
+    for k, v in _config_data.mapping.items():
+        globals()[k] = _main.AttrAccess(v)

--- a/buchschloss/config/__init__.py
+++ b/buchschloss/config/__init__.py
@@ -7,7 +7,7 @@ _config_data = _main.get_config()
 
 
 def start():
-    """load config data and provide feedback to STDOUT"""
+    """provide config feedback to STDOUT"""
     print('No configuration errors found.')
     if (_config_data['debug']
             and input('Do you want to see the current settings? ')

--- a/buchschloss/config/configspec.cfg
+++ b/buchschloss/config/configspec.cfg
@@ -126,6 +126,17 @@ debug = boolean(default=false)
         file = file
 
 
+# User Interface configuration
+# ============================
+# the following blocks deal with UI config. You may put common subsections
+# into a special top-level [ui] section. The values will be merged into every
+# individual UI section
+
+# configuration for the cli user interface
+[cli]
+    [[intro]]
+        text = string(default=None)
+
 # configuration for the gui2 user interface
 [gui2]
     # how many items to display in a selection popup

--- a/buchschloss/config/configspec.cfg
+++ b/buchschloss/config/configspec.cfg
@@ -134,6 +134,11 @@ debug = boolean(default=false)
 
 # configuration for the cli user interface
 [cli]
+    [[answers]]
+        # which answers will be interpreted as "yes" (lower case)
+        yes = list(default=list('y', 'yes', 'ok'))
+        # and as "no" (also lower case)
+        no = list(default=list('n', 'no'))
     [[intro]]
         text = string(default=None)
 

--- a/buchschloss/config/main.py
+++ b/buchschloss/config/main.py
@@ -226,7 +226,7 @@ def check_smtp_auth_data(config):
     """check SMTP auth data"""
     # once optional sections are supported, this can go away
     if ((config['utils']['email']['smtp']['username'] is None)
-            == (config['utils']['email']['smtp']['password'] is None)):
+            != (config['utils']['email']['smtp']['password'] is None)):
         raise ConfigError(
             'smtp.username and smtp.password must both be given or omitted')
 

--- a/buchschloss/config/main.py
+++ b/buchschloss/config/main.py
@@ -5,7 +5,6 @@ import datetime
 import json
 import contextlib
 from collections.abc import Mapping
-import pprint
 import typing as T
 
 import configobj
@@ -16,7 +15,6 @@ CONFIG_FILE_ENV = 'BUCHSCHLOSS_CONFIG'
 MODULE_DIR = os.path.dirname(__file__)
 INCLUDE_NAME = 'include'  # I'd love to make this configurable...
 UI_SECTIONS = ('cli', 'gui2')
-config_data = None
 ExceptSpec = T.Union[T.Type[BaseException], T.Tuple[T.Type[BaseException], ...]]
 ActuallyPathLike = T.Union[bytes, str, os.PathLike]
 
@@ -179,7 +177,7 @@ def get_config():
 
 def config_error(error_spec, invalid_files):
     """print error information to STDERR"""
-    def pprint_errors(errors, nesting=' '):
+    def pprint_errors(errors, nesting=''):
         """display errors"""
         for k, v in errors.items():
             if isinstance(v, dict):
@@ -238,4 +236,9 @@ def redirect_stderr(config):
 
 
 pre_validation = [merge_ui]
-post_validation = (insert_name_data, apply_ui_intro_text_default, check_smtp_auth_data)
+post_validation = (
+    insert_name_data,
+    apply_ui_intro_text_default,
+    check_smtp_auth_data,
+    redirect_stderr,
+)

--- a/buchschloss/config/main.py
+++ b/buchschloss/config/main.py
@@ -1,0 +1,241 @@
+"""Get configuration settings"""
+import os
+import sys
+import datetime
+import json
+import contextlib
+from collections.abc import Mapping
+import pprint
+import typing as T
+
+import configobj
+
+from .validation import validator
+
+CONFIG_FILE_ENV = 'BUCHSCHLOSS_CONFIG'
+MODULE_DIR = os.path.dirname(__file__)
+INCLUDE_NAME = 'include'  # I'd love to make this configurable...
+UI_SECTIONS = ('cli', 'gui2')
+config_data = None
+ExceptSpec = T.Union[T.Type[BaseException], T.Tuple[T.Type[BaseException], ...]]
+ActuallyPathLike = T.Union[bytes, str, os.PathLike]
+
+
+class ConfigError(Exception):
+    """configuration error"""
+
+
+class DummyErrorFile:
+    """Revert errors to log.
+
+    Attributes:
+        error_happened: True if write() was called
+        error_file: the log file name
+        error_texts: list of the error messages wrote to the log file for later use
+            e.g. display, email, ..."""
+
+    def __init__(self, error_file='error.log'):
+        self.error_happened = False
+        self.error_texts = []
+        self.error_file = 'error.log'
+        with open(error_file, 'a', encoding='UTF-8') as f:
+            f.write('\n\nSTART: ' + str(datetime.datetime.now()) + '\n')
+
+    def write(self, msg):
+        self.error_happened = True
+        self.error_texts.append(msg)
+        while True:
+            try:
+                with open(self.error_file, 'a', encoding='UTF-8') as f:
+                    f.write(msg)
+            except OSError:
+                pass
+            else:
+                break
+
+
+class AttrAccess:
+    """Provide attribute access to mappings, supporting nesting"""
+    EMPTY_INST = type('', (), {'__repr__': lambda s: 'AttrAccess.EMPTY_INST'})()
+
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def get(self, item, fallback=EMPTY_INST):
+        """return ``item`` if present, otherwise the given fallback
+            (an empty AttrAccess instance by default)"""
+        if fallback is self.EMPTY_INST:
+            fallback = type(self)({})
+        val = self.mapping.get(item, fallback)
+        if isinstance(val, Mapping):
+            val = type(self)(val)
+        return val
+
+    def __getitem__(self, item):
+        return self.mapping[item]
+
+    def __getattr__(self, item):
+        val = self.mapping[item.replace('_', ' ')]
+        if isinstance(val, Mapping):
+            val = type(self)(val)
+        return val
+
+
+def load_file(path: ActuallyPathLike,
+              loader: T.Callable[[T.TextIO], T.MutableMapping] = configobj.ConfigObj,
+              load_error: ExceptSpec = configobj.ConfigObjError,
+              ) -> T.Tuple[configobj.ConfigObj, T.Set[ActuallyPathLike]]:
+    """recursively load a file as ConfigObj. Return (<ConfigObj>, <set of invalid paths>)
+
+        The invalid paths returned may be nonexistent or unparseable
+        ``loader`` specifies how to load the file
+        ``load_error`` is used to catch exceptions while loading the file
+    """
+    def include_config(section: configobj.Section):
+        """recursively read included files and merge"""
+        for k, v in section.items():
+            if k == INCLUDE_NAME:
+                if isinstance(v, str):
+                    v = [v]
+                elif isinstance(v, configobj.Section):
+                    continue  # could also raise an error or add some filename to errors
+                del section[k]
+                for new_file in v:
+                    new_section, new_errors = load_file(new_file, loader, load_error)
+                    section.merge(new_section)
+                    errors.update(new_errors)
+            elif isinstance(v, configobj.Section):
+                include_config(v)
+
+    errors = set()
+    try:
+        f = open(path)
+    except OSError:
+        return configobj.ConfigObj({}), {path}
+    try:
+        config = loader(f)
+    except load_error:
+        return configobj.ConfigObj({}), {path}
+    finally:
+        f.close()
+    if not isinstance(config, configobj.ConfigObj):
+        config = configobj.ConfigObj(config)
+    include_config(config)
+    return config, errors
+
+
+def load_names(name_file: ActuallyPathLike,
+               name_format: str
+               ) -> T.Mapping:
+    """Load the name file with inclusions ignoring errors"""
+    def convert_name_data(data):
+        if isinstance(data, str):
+            return data
+        elif isinstance(data, T.Mapping):
+            return {k.lower(): convert_name_data(v) for k, v in data.items()}
+        else:
+            return ''
+
+    loaders = {
+        'json': (json.load, json.JSONDecodeError),
+        'configobj': (configobj.ConfigObj, configobj.ConfigObjError),
+    }
+    name_data, __ = load_file(name_file, *loaders[name_format])
+    # special case the only list
+    level_list = name_data.pop('level names', ())
+    if not isinstance(level_list, T.Sequence) or len(level_list) != 5:
+        level_list = ['level_{}'.format(i) for i in range(5)]
+    processed_data = convert_name_data(name_data)
+    processed_data['level names'] = level_list
+    return processed_data
+
+
+def get_config():
+    """get configuration data as an AttrAccess object"""
+    try:
+        filename = os.environ[CONFIG_FILE_ENV]
+    except KeyError:
+        raise ConfigError('environment variable BUCHSCHLOSS_CONFIG not found') from None
+
+    config, invalid_files = load_file(filename)
+    config = configobj.ConfigObj(
+        config, configspec=os.path.join(MODULE_DIR, 'configspec.cfg'))
+    for f in pre_validation:
+        f(config)
+    val = config.validate(validator)
+    if isinstance(val, Mapping):
+        config_error(val, invalid_files)
+        sys.exit(1)
+    else:
+        if invalid_files:
+            with contextlib.redirect_stdout(sys.stderr):
+                print('\nThe following configuration files could not be loaded:')
+                print('\n'.join(invalid_files))
+                print()
+        for f in post_validation:
+            f(config)
+        return AttrAccess(config)
+
+
+def config_error(error_spec, invalid_files):
+    """print error information to STDERR"""
+    def pprint_errors(errors, nesting=' '):
+        """display errors"""
+        for k, v in errors.items():
+            if isinstance(v, dict):
+                print(nesting + '\\_', k)
+                pprint_errors(v, nesting + ' |')
+            else:
+                print(nesting, k, 'OK' if v else 'INVALID')
+
+    with contextlib.redirect_stdout(sys.stderr):
+        print('--- ERROR IN CONFIG FILE FORMAT ---\n')
+        pprint_errors(error_spec)
+        print('\n\nSee the confspec.cfg file for information on how the data has to be')
+        if invalid_files:
+            print('\nThe following configuration files could not be loaded:')
+            print('\n'.join(invalid_files))
+
+
+def merge_ui(config):
+    """merge the [ui] section into each UI section"""
+    if 'ui' in config:
+        for ui_sec in UI_SECTIONS:
+            sec = config.setdefault(ui_sec, {})
+            sec.merge(config['ui'])
+        del config['ui']
+
+
+def insert_name_data(config):
+    """load name data into [utils][names]"""
+    config['utils']['names'] = load_names(
+        config['utils']['names']['file'], config['utils']['names']['format'])
+
+
+def apply_ui_intro_text_default(config):
+    """insert the newline-including default for [<ui>][intro][text]"""
+    for ui_sec in UI_SECTIONS:
+        sec = config[ui_sec]
+        # multiline defaults aren't allowed (AFAIK)
+        if sec['intro']['text'] is None:
+            sec['intro']['text'] = \
+                'Buchschloss\n\nhttps://github.com/mik2k2/buchschloss'
+
+
+def check_smtp_auth_data(config):
+    """check SMTP auth data"""
+    # once optional sections are supported, this can go away
+    if ((config['utils']['email']['smtp']['username'] is None)
+            ^ (config['utils']['email']['smtp']['password'] is None)):
+        raise ConfigError(
+            'smtp.username and smtp.password must both be given or omitted')
+
+
+def redirect_stderr(config):
+    """redirect STDERR to error.log when not debugging"""
+    if not config['debug']:
+        sys.stderr = DummyErrorFile()
+
+
+pre_validation = [merge_ui]
+post_validation = (insert_name_data, apply_ui_intro_text_default, check_smtp_auth_data)

--- a/buchschloss/config/main.py
+++ b/buchschloss/config/main.py
@@ -12,6 +12,9 @@ import configobj
 from .validation import validator
 
 CONFIG_FILE_ENV = 'BUCHSCHLOSS_CONFIG'
+DEFAULT_INTRO_TEXT = """Buchschloss
+
+https://github.com/mik2k2/buchschloss"""
 MODULE_DIR = os.path.dirname(__file__)
 INCLUDE_NAME = 'include'  # I'd love to make this configurable...
 UI_SECTIONS = ('cli', 'gui2')
@@ -216,15 +219,14 @@ def apply_ui_intro_text_default(config):
         sec = config[ui_sec]
         # multiline defaults aren't allowed (AFAIK)
         if sec['intro']['text'] is None:
-            sec['intro']['text'] = \
-                'Buchschloss\n\nhttps://github.com/mik2k2/buchschloss'
+            sec['intro']['text'] = DEFAULT_INTRO_TEXT
 
 
 def check_smtp_auth_data(config):
     """check SMTP auth data"""
     # once optional sections are supported, this can go away
     if ((config['utils']['email']['smtp']['username'] is None)
-            ^ (config['utils']['email']['smtp']['password'] is None)):
+            == (config['utils']['email']['smtp']['password'] is None)):
         raise ConfigError(
             'smtp.username and smtp.password must both be given or omitted')
 

--- a/exampleconfig.cfg
+++ b/exampleconfig.cfg
@@ -102,14 +102,25 @@ debug = false
         file = example_names.json
 
 
-# configuration for the gui2 user interface
-[gui2]
-    # shown on start
+# User Interface configuration
+# ============================
+# the following blocks deal with UI config. You may put common subsections
+# into a special top-level [ui] section. The values will be merged into every
+# individual UI section
+
+# configuration for cli and gui2
+[ui]
     [[intro]]
         # default: Buchschloss\n\nhttps://github.com/mik2k2/buchschloss
         text = """Buchschloss
 
 Example config"""
+
+# configuration for the gui2 user interface
+[gui2]
+    # shown on start
+    [[intro]]
+        # text set in [ui]
         # default font: Times 70
 
     # default values for entry widgets

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -6,7 +6,7 @@ import json
 
 from configobj import validate
 import pytest
-from buchschloss import config
+from buchschloss.config import main
 from buchschloss.config import validation as config_val
 
 
@@ -65,7 +65,7 @@ def test_load_file(tmpdir):
     f2.write('b = 1\n[sec]\na = 2\ninclude = {},{}'.format(f3, f4))
     f3.write('b = 2')
     f4.write('invalid config file')
-    co, errors = config.load_file(f1)
+    co, errors = main.load_file(f1)
     assert errors == {str(f4)}
     assert co.dict() == {'a': '1', 'b': '1', 'sec': {'a': '2', 'b': '2'}}
 
@@ -77,6 +77,6 @@ def test_load_file_json(tmpdir):
     f2.write('{"b": "1", "sec": {"a": "2", "include": ["%s", "%s"]}}' % (f3, f4))
     f3.write('{"b": "2"}')
     f4.write('invalid config file')
-    co, errors = config.load_file(f1, json.load, json.JSONDecodeError)
+    co, errors = main.load_file(f1, json.load, json.JSONDecodeError)
     assert errors == {str(f4)}
     assert co.dict() == {'a': '1', 'b': '1', 'sec': {'a': '2', 'b': '2'}}


### PR DESCRIPTION
closes #52 

Move most of the config logic to new ``config.main``, keeping the config namespace clean.
Add new ``[ui]`` section that is merged into all UI sections to avoid repetitions in config files.